### PR TITLE
updated esprima dependency version

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -143,7 +143,7 @@
                           "version": "1.0.0",
                           "dependencies": {
                             "esprima": {
-                              "version": "git://github.com/ariya/esprima.git#a41a40b49046747b3af57341cda048bbd3d9df79"
+                              "version": "2.3.0"
                             },
                             "escodegen": {
                               "version": "1.3.3",
@@ -184,13 +184,13 @@
                               "version": "2.1.0"
                             },
                             "esprima": {
-                              "version": "git://github.com/ariya/esprima.git#a41a40b49046747b3af57341cda048bbd3d9df79"
+                              "version": "2.3.0"
                             },
                             "recast": {
                               "version": "0.6.10",
                               "dependencies": {
                                 "esprima": {
-                                  "version": "git+https://github.com/ariya/esprima.git#a41a40b49046747b3af57341cda048bbd3d9df79"
+                                  "version": "2.3.0"
                                 },
                                 "source-map": {
                                   "version": "0.1.32",


### PR DESCRIPTION
The referenced branch is no longer available. Version 2.3.0 has replaced
the missing branch.