### PR TITLE
Elaborate API for IronRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Then, you could send a `pageview` from IronRouter:
 ```
 Router.onRun(function() {
   analytics.page();
+  this.next(); // If using versions later than 0.9.4
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then, you could send a `pageview` from IronRouter:
 ```
 Router.onRun(function() {
   analytics.page();
-  this.next(); // If using versions later than 0.9.4
+  this.next(); // If using versions of IronRouter later than 0.9.4
 });
 ```
 


### PR DESCRIPTION
> onRun and onBeforeAction hooks now require you to call this.next()

https://github.com/iron-meteor/iron-router#hooks